### PR TITLE
Commit Summary

### DIFF
--- a/ResearchTool/email_agent.py
+++ b/ResearchTool/email_agent.py
@@ -29,7 +29,6 @@ import sendgrid
 from sendgrid.helpers.mail import Email, Mail, Content, To
 from agents import Agent, function_tool
 
-
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------

--- a/ResearchTool/llm_helper.py
+++ b/ResearchTool/llm_helper.py
@@ -1,0 +1,15 @@
+from enum import Enum
+
+class LLM_MODEL_NAME(Enum):
+    GEMINI = "gemini-1.5-flash"     # free tier today; paid tier not yet set :contentReference[oaicite:0]{index=0}
+    GROK   = "grok-3-mini"          # “mini” is the low-cost option in xAI’s list :contentReference[oaicite:1]{index=1}
+    GROQ   = "llama3-8b-8192"       # $0.05 / $0.08 per M tokens on GroqCloud :contentReference[oaicite:2]{index=2}
+    OPENAI = "gpt-4.1-nano"         # $0.10 / $0.40 per M tokens—cheapest OpenAI text model :contentReference[oaicite:3]{index=3}
+    OLLAMA = "llama3:8b"            # local 8-B Llama-3; no token cost (CPU/GPU only)
+
+class LLM_BASE_URL(Enum):
+    OPENAI_URL = "https://api.openai.com/v1"
+    GEMINI_URL = "https://generativelanguage.googleapis.com/v1beta"
+    GROK_URL = "https://api.x.ai/v1"
+    GROQ_URL = "https://api.groq.com/openai/v1"
+    OLLAMA_URL = "http://localhost:11434/v1"

--- a/ResearchTool/llm_model_selector.py
+++ b/ResearchTool/llm_model_selector.py
@@ -1,0 +1,40 @@
+import os
+from openai import AsyncOpenAI
+from agents import OpenAIChatCompletionsModel
+from llm_helper import LLM_MODEL_NAME, LLM_BASE_URL
+from dotenv import load_dotenv
+
+# ---------------------------------------------------------------------------
+# llm_model_selector.py
+# Helper to select and instantiate an OpenAIChatCompletionsModel.
+# - Reads API key and base URL from environment variables using a naming convention.
+# - Falls back to OPENAI if a key is missing.
+# - Enforces enum type for clarity and safety.
+# ---------------------------------------------------------------------------
+
+def get_model(provider: LLM_MODEL_NAME = LLM_MODEL_NAME.OPENAI) -> OpenAIChatCompletionsModel:
+    """
+    Selects and instantiates a chat model for the given provider.
+    - Reads <PROVIDER>_API_KEY and <PROVIDER>_URL from environment.
+    - Falls back to OPENAI if API key is missing.
+    - Only accepts LLM_MODEL_NAME enums.
+    """
+    # Type safety: Only allow enum, never a string.
+    if not isinstance(provider, LLM_MODEL_NAME):
+        raise TypeError("provider must be a LLM_MODEL_NAME enum value")
+
+    # Fetch provider credentials and base URL.
+    key = os.getenv(f"{provider.name}_API_KEY")
+    url = getattr(LLM_BASE_URL, f"{provider.name}_URL", LLM_BASE_URL.OPENAI_URL).value
+    model = provider.value
+
+    # Fallback: If key is missing, switch to OpenAI defaults.
+    if not key:
+        key = os.getenv("OPENAI_API_KEY")
+        url = LLM_BASE_URL.OPENAI_URL.value
+        model = LLM_MODEL_NAME.OPENAI.value
+
+    # Instantiate the async client and model wrapper.
+    client = AsyncOpenAI(api_key=key, base_url=url)
+    model = OpenAIChatCompletionsModel(model=model, openai_client=client)
+    return model

--- a/ResearchTool/planner_agent.py
+++ b/ResearchTool/planner_agent.py
@@ -26,7 +26,7 @@ from agents import Agent
 # Configuration
 # ---------------------------------------------------------------------------
 # Number of distinct searches the model should propose
-HOW_MANY_SEARCHES = 5
+HOW_MANY_SEARCHES = 3
 
 # Model configuration
 llm_model_to_use = os.getenv("DEFAULT_OPENAI_MODEL")

--- a/ResearchTool/research_manager.py
+++ b/ResearchTool/research_manager.py
@@ -22,10 +22,12 @@ asynchronously to maximize throughput.
 # ---------------------------------------------------------------------------
 import asyncio
 from agents import Runner, trace, gen_trace_id
-from search_agent import search_agent
+
+from search_agent import get_search_agent
 from planner_agent import planner_agent, WebSearchItem, WebSearchPlan
 from writer_agent import writer_agent, ReportData
 from email_agent import email_agent
+from llm_helper import LLM_MODEL_NAME
 
 
 # ---------------------------------------------------------------------------
@@ -58,7 +60,7 @@ class ResearchManager:
             print("Starting research...")
             search_plan = await self.plan_searches(query)
             yield "Searches planned, starting to search..."  
-            
+            self.search_agent = get_search_agent(LLM_MODEL_NAME.GEMINI)
             search_results = await self.perform_searches(search_plan)
             yield "Searches complete, writing report..."
             
@@ -122,7 +124,7 @@ class ResearchManager:
         input = f"Search term: {item.query}\nReason for searching: {item.reason}"
         try:
             result = await Runner.run(
-                search_agent,
+                self.search_agent,
                 input,
             )
             return str(result.final_output)

--- a/ResearchTool/search_agent.py
+++ b/ResearchTool/search_agent.py
@@ -1,49 +1,103 @@
-# ---------------------------------------------------------------------------
-# Description
-# ---------------------------------------------------------------------------
-"""
-Search Agent Module
+from llm_model_selector import get_model
+from llm_helper import LLM_MODEL_NAME
+from agents import Agent, ModelSettings, WebSearchTool
 
-This module defines a SearchAgent that performs web searches and generates concise
-summaries of the search results. The agent is designed to be part of a larger
-research pipeline, providing focused and relevant information for report generation.
-
-The agent:
-- Performs web searches using provided search terms
-- Generates brief, focused summaries (2-3 paragraphs, <300 words)
-- Captures essential information while removing unnecessary details
-"""
-
-# ---------------------------------------------------------------------------
-# Imports
-# ---------------------------------------------------------------------------
-import os
-from agents import Agent, WebSearchTool, ModelSettings
-
-
-# ---------------------------------------------------------------------------
-# Configuration
-# ---------------------------------------------------------------------------
-# The language model to use
-llm_model_to_use = os.getenv("DEFAULT_OPENAI_MODEL")
-
-# System prompt instructions for the language model
+# -----------------------------------------------------------------------------
+# System prompt for the agent's LLM.
+# Used as the "system message" to instruct the language model how to behave.
+# -----------------------------------------------------------------------------
 INSTRUCTIONS = (
     "You are a research assistant. Given a search term, you search the web for that term and "
-    "produce a concise summary of the results. The summary must 2-3 paragraphs and less than 300 "
-    "words. Capture the main points. Write succintly, no need to have complete sentences or good "
-    "grammar. This will be consumed by someone synthesizing a report, so its vital you capture the "
+    "produce a concise summary of the results. The summary must be 2-3 paragraphs and less than 300 "
+    "words. Capture the main points. Write succinctly, no need to have complete sentences or good "
+    "grammar. This will be consumed by someone synthesizing a report, so it's vital you capture the "
     "essence and ignore any fluff. Do not include any additional commentary other than the summary itself."
 )
 
+# -----------------------------------------------------------------------------
+# Factory function to create a Search Agent using the specified LLM model.
+# This allows easy injection of different models (OpenAI, Gemini, etc.)
+# -----------------------------------------------------------------------------
+def get_search_agent(provider: LLM_MODEL_NAME):
+    """
+    Creates and returns a configured Search Agent for web search and summarization.
 
-# ---------------------------------------------------------------------------
-# Agent Configuration
-# ---------------------------------------------------------------------------
-search_agent = Agent(
-    name="Search agent",                                    # Name used for logging/tracing
-    instructions=INSTRUCTIONS,                              # System prompt for the language model
-    tools=[WebSearchTool(search_context_size="low")],       # Web search tool with minimal context
-    model=llm_model_to_use,                                 # Language model to use
-    model_settings=ModelSettings(tool_choice="required"),   # Require tool usage
-)
+    :param provider: The language model provider to use (must be LLM_MODEL_NAME enum).
+    :return: Agent instance configured with the chosen LLM model and web search tool.
+    """
+    # Get the model instance for the specified provider
+    llm_model = get_model(provider)
+    # Instantiate and return the agent
+    return Agent(
+        name="Search agent",
+        instructions=INSTRUCTIONS,
+        tools=[WebSearchTool(search_context_size="low")],
+        model=llm_model,
+        model_settings=ModelSettings(tool_choice="required"),
+    )
+
+# Example usage:
+# agent = get_search_agent(LLM_MODEL_NAME.OPENAI)
+# agent = get_search_agent(LLM_MODEL_NAME.GEMINI)
+
+# -----------------------------------------------------------------------------
+# Example usage (uncomment as needed)
+# -----------------------------------------------------------------------------
+# agent = get_search_agent(LLM_MODEL_NAME.OPENAI)
+# agent = get_search_agent(LLM_MODEL_NAME.GEMINI)
+
+
+
+# # ---------------------------------------------------------------------------
+# # Description
+# # ---------------------------------------------------------------------------
+# """
+# Search Agent Module
+
+# This module defines a SearchAgent that performs web searches and generates concise
+# summaries of the search results. The agent is designed to be part of a larger
+# research pipeline, providing focused and relevant information for report generation.
+
+# The agent:
+# - Performs web searches using provided search terms
+# - Generates brief, focused summaries (2-3 paragraphs, <300 words)
+# - Captures essential information while removing unnecessary details
+# """
+
+# # ---------------------------------------------------------------------------
+# # Imports
+# # ---------------------------------------------------------------------------
+# import os
+# from openai import OpenAI
+# from agents import Agent, WebSearchTool, ModelSettings
+# from llm_model_selector import get_model
+# from llm_helper import LLM_MODEL_NAME
+
+# # ---------------------------------------------------------------------------
+# # Configuration
+# # ---------------------------------------------------------------------------
+# # The language model to use - using Gemini from environment
+# # llm_model_to_use = os.getenv("DEFAULT_OPENAI_MODEL")
+# llm_model_to_use = get_model(LLM_MODEL_NAME.GEMINI)
+
+
+# # System prompt instructions for the language model
+# INSTRUCTIONS = (
+#     "You are a research assistant. Given a search term, you search the web for that term and "
+#     "produce a concise summary of the results. The summary must 2-3 paragraphs and less than 300 "
+#     "words. Capture the main points. Write succintly, no need to have complete sentences or good "
+#     "grammar. This will be consumed by someone synthesizing a report, so its vital you capture the "
+#     "essence and ignore any fluff. Do not include any additional commentary other than the summary itself."
+# )
+
+
+# # ---------------------------------------------------------------------------
+# # Agent Configuration
+# # ---------------------------------------------------------------------------
+# search_agent = Agent(
+#     name="Search agent",                                    # Name used for logging/tracing
+#     instructions=INSTRUCTIONS,                              # System prompt for the language model
+#     tools=[WebSearchTool(search_context_size="low")],       # Web search tool with minimal context
+#     model=llm_model_to_use,                                 # Language model to use
+#     model_settings=ModelSettings(tool_choice="required"),   # Require tool usage
+# )

--- a/ResearchTool/tests/tests_llm_model_selector.py
+++ b/ResearchTool/tests/tests_llm_model_selector.py
@@ -1,0 +1,109 @@
+# tests_llm_model_selector.py
+
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+from llm_helper import LLM_MODEL_NAME, LLM_BASE_URL
+from llm_model_selector import get_model
+
+# ------------------------------------------------------------------------------
+# Test: get_model returns a model with OpenAI settings if OPENAI is chosen.
+# Assumption:
+#   - The function reads OPENAI_API_KEY and OPENAI_URL from environment.
+# Setup:
+#   - Set OPENAI_API_KEY for this test.
+# Expectation:
+#   - AsyncOpenAI and OpenAIChatCompletionsModel are called with the correct parameters.
+# ------------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_get_model_openai(monkeypatch):
+    # Set OPENAI_API_KEY in the environment for this test.
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    # Patch the client and model wrapper to avoid real API calls.
+    with patch("llm_model_selector.AsyncOpenAI") as mock_client, \
+         patch("llm_model_selector.OpenAIChatCompletionsModel") as mock_model:
+        mock_client.return_value = MagicMock(name="openai_client")
+        mock_model.return_value = MagicMock(name="model_instance")
+        model = await get_model(LLM_MODEL_NAME.OPENAI)
+    # The client should be initialized with our test API key and OpenAI base URL.
+    mock_client.assert_called_once_with(
+        api_key="test-key",
+        base_url=LLM_BASE_URL.OPENAI_URL.value
+    )
+    # The model wrapper should be initialized with correct model name and client.
+    mock_model.assert_called_once_with(
+        model=LLM_MODEL_NAME.OPENAI.value,
+        openai_client=mock_client.return_value
+    )
+    # The function should return our mocked model instance.
+    assert model is mock_model.return_value
+
+# ------------------------------------------------------------------------------
+# Test: get_model returns a Gemini model with Gemini settings if GEMINI is chosen.
+# Assumption:
+#   - The function reads GEMINI_API_KEY and GEMINI_URL from environment.
+# Setup:
+#   - Set GEMINI_API_KEY for this test.
+# Expectation:
+#   - AsyncOpenAI and model wrapper are called with Gemini's key and URL.
+# ------------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_get_model_gemini(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "gemini-key")
+    with patch("llm_model_selector.AsyncOpenAI") as mock_client, \
+         patch("llm_model_selector.OpenAIChatCompletionsModel") as mock_model:
+        mock_client.return_value = MagicMock(name="gemini_client")
+        mock_model.return_value = MagicMock(name="model_instance")
+        model = await get_model(LLM_MODEL_NAME.GEMINI)
+    mock_client.assert_called_once_with(
+        api_key="gemini-key",
+        base_url=getattr(LLM_BASE_URL, "GEMINI_URL").value
+    )
+    mock_model.assert_called_once_with(
+        model=LLM_MODEL_NAME.GEMINI.value,
+        openai_client=mock_client.return_value
+    )
+    assert model is mock_model.return_value
+
+# ------------------------------------------------------------------------------
+# Test: get_model falls back to OpenAI if provider's API key is missing.
+# Assumption:
+#   - If the selected provider's key is missing, function uses OpenAI's key and URL.
+# Setup:
+#   - Ensure GROK_API_KEY is not set, set OPENAI_API_KEY.
+# Expectation:
+#   - Function returns a model with OpenAI settings.
+# ------------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_fallback_to_openai(monkeypatch):
+    monkeypatch.delenv("GROK_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-fallback")
+    with patch("llm_model_selector.AsyncOpenAI") as mock_client, \
+         patch("llm_model_selector.OpenAIChatCompletionsModel") as mock_model:
+        mock_client.return_value = MagicMock(name="openai_client")
+        mock_model.return_value = MagicMock(name="model_instance")
+        # Simulate GROK, but GROK_API_KEY missing.
+        model = await get_model(LLM_MODEL_NAME.GROK)
+    # Should use OpenAI settings.
+    mock_client.assert_called_once_with(
+        api_key="openai-fallback",
+        base_url=LLM_BASE_URL.OPENAI_URL.value
+    )
+    mock_model.assert_called_once_with(
+        model=LLM_MODEL_NAME.OPENAI.value,
+        openai_client=mock_client.return_value
+    )
+
+# ------------------------------------------------------------------------------
+# Test: get_model raises TypeError if input is not an LLM_MODEL_NAME enum.
+# Assumption:
+#   - Function only accepts LLM_MODEL_NAME, not string.
+# Setup:
+#   - Call with string.
+# Expectation:
+#   - TypeError is raised.
+# ------------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_type_guard():
+    with pytest.raises(TypeError):
+        await get_model("OPENAI")  # Not an enum member!

--- a/ResearchTool/tests/tests_search_agent.py
+++ b/ResearchTool/tests/tests_search_agent.py
@@ -1,0 +1,34 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from llm_helper import LLM_MODEL_NAME
+from search_agent import get_search_agent
+
+# -----------------------------------------------------------------------------
+# Test: get_search_agent should correctly create an agent using the specified model.
+# -----------------------------------------------------------------------------
+def test_get_search_agent_with_provider():
+    """
+    Test that get_search_agent uses the given provider and passes the correct model
+    to the Agent constructor.
+    """
+    # Mock get_model to avoid real model instantiation
+    with patch("search_agent.get_model") as mock_get_model, \
+         patch("search_agent.Agent") as mock_agent:
+        fake_model = MagicMock(name="fake_llm_model")
+        mock_get_model.return_value = fake_model
+        result = get_search_agent(LLM_MODEL_NAME.GEMINI)
+        # Ensure get_model was called with the right provider
+        mock_get_model.assert_called_once_with(LLM_MODEL_NAME.GEMINI)
+        # Ensure Agent was created with our fake model
+        mock_agent.assert_called_once()
+        assert result == mock_agent.return_value
+
+# -----------------------------------------------------------------------------
+# Test: get_search_agent fails if not given a valid LLM_MODEL_NAME.
+# -----------------------------------------------------------------------------
+def test_get_search_agent_type_error():
+    """
+    Test that get_search_agent raises a TypeError if the provider is not an enum.
+    """
+    with pytest.raises(TypeError):
+        get_search_agent("OPENAI")  # Not an enum; should fail

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,4 +43,6 @@ dependencies = [
 [dependency-groups]
 dev = [
     "ipykernel>=6.29.5",
+    "pytest>=8.4.0",
+    "pytest-asyncio>=1.0.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -50,6 +50,8 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "ipykernel" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
 ]
 
 [package.metadata]
@@ -90,7 +92,11 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ipykernel", specifier = ">=6.29.5" }]
+dev = [
+    { name = "ipykernel", specifier = ">=6.29.5" },
+    { name = "pytest", specifier = ">=8.4.0" },
+    { name = "pytest-asyncio", specifier = ">=1.0.0" },
+]
 
 [[package]]
 name = "aiofiles"
@@ -1121,6 +1127,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/33/08/c1395a292bb23fd03bdf572a1357c5a733d3eecbab877641ceacab23db6e/importlib_metadata-8.6.1.tar.gz", hash = "sha256:310b41d755445d74569f993ccfc22838295d9fe005425094fad953d7f15c8580", size = 55767, upload-time = "2025-01-20T22:21:30.429Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/9d/0fb148dc4d6fa4a7dd1d8378168d9b4cd8d4560a6fbf6f0121c5fc34eb68/importlib_metadata-8.6.1-py3-none-any.whl", hash = "sha256:02a89390c1e15fdfdc0d7c6b25cb3e62650d0494005c97d6f148bf5b9787525e", size = 26971, upload-time = "2025-01-20T22:21:29.177Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
 ]
 
 [[package]]
@@ -2310,6 +2325,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "polygon-api-client"
 version = "1.14.5"
 source = { registry = "https://pypi.org/simple" }
@@ -2652,6 +2676,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9f/bb/18dc3062d37db6c491392007dfd1a7f524bb95886eb956569ac38a23a784/PyPDF2-3.0.1.tar.gz", hash = "sha256:a74408f69ba6271f71b9352ef4ed03dc53a31aa404d29b5d31f53bfecfee1440", size = 227419, upload-time = "2022-12-31T10:36:13.13Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/5e/c86a5643653825d3c913719e788e41386bee415c2b87b4f955432f2de6b2/pypdf2-3.0.1-py3-none-any.whl", hash = "sha256:d16e4205cfee272fbdc0568b68d82be796540b1537508cef59388f839c191928", size = 232572, upload-time = "2022-12-31T10:36:10.327Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/aa/405082ce2749be5398045152251ac69c0f3578c7077efc53431303af97ce/pytest-8.4.0.tar.gz", hash = "sha256:14d920b48472ea0dbf68e45b96cd1ffda4705f33307dcc86c676c1b5104838a6", size = 1515232, upload-time = "2025-06-02T17:36:30.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/de/afa024cbe022b1b318a3d224125aa24939e99b4ff6f22e0ba639a2eaee47/pytest-8.4.0-py3-none-any.whl", hash = "sha256:f40f825768ad76c0977cbacdf1fd37c6f7a468e460ea6a0636078f8972d4517e", size = 363797, upload-time = "2025-06-02T17:36:27.859Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/d4/14f53324cb1a6381bef29d698987625d80052bb33932d8e7cbf9b337b17c/pytest_asyncio-1.0.0.tar.gz", hash = "sha256:d15463d13f4456e1ead2594520216b225a16f781e144f8fdf6c5bb4667c48b3f", size = 46960, upload-time = "2025-05-26T04:54:40.484Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/05/ce271016e351fddc8399e546f6e23761967ee09c8c568bbfbecb0c150171/pytest_asyncio-1.0.0-py3-none-any.whl", hash = "sha256:4f024da9f1ef945e680dc68610b52550e36590a67fd31bb3b4943979a1f90ef3", size = 15976, upload-time = "2025-05-26T04:54:39.035Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Tickets: AAEC2-1, AAEC2-12, AAEC2-13
Summary: Add LLM model selection modules, refactor agent, and add tests

Added
pytest as the test framework

llm_helper module
Holds default LLM_MODEL_NAME and base URLs

llm_model_selector module
Returns a model for the given LLM_MODEL_NAME, with fallback to OpenAI

Unit tests for llm_model_selector and search_agent modules

Changed
Refactored search_agent
Now uses llm_model_selector for model injection

General

Added and improved code comments throughout for clarity and maintainability